### PR TITLE
Fix imaging settings: add to OV20i, remove unsupported fields from OV80i

### DIFF
--- a/ov20i_v2026.2.1_openapi.yml
+++ b/ov20i_v2026.2.1_openapi.yml
@@ -388,6 +388,25 @@ paths:
                   deployable:
                     type: boolean
 
+  /edge/recipe/{id}/imaging-settings:
+    parameters:
+      - $ref: "#/components/parameters/RecipeId"
+    patch:
+      tags: [Recipe]
+      summary: Update imaging settings for a recipe
+      operationId: updateImagingSettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImagingSettings"
+      responses:
+        "204":
+          description: Updated successfully
+        "400":
+          description: Missing or invalid body
+
   # ── Camera & Captures ───────────────────────────────────────
   /edge/camera/capture:
     post:
@@ -1463,6 +1482,14 @@ paths:
 
 # ═══════════════════════════════════════════════════════════════
 components:
+  parameters:
+    RecipeId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+
   schemas:
     SuccessResponse:
       type: object
@@ -1613,3 +1640,86 @@ components:
         basic_flow_metadata:
           type: object
           additionalProperties: true
+
+    # ── Imaging Settings ─────────────────────────────────────────
+    ImagingSettings:
+      type: object
+      properties:
+        acq_mode:
+          type: integer
+          enum: [1, 2, 3, 4, 5, 6]
+        aligner_trigger_debounce_ms:
+          type: integer
+        awb_blue:
+          type: integer
+        awb_green:
+          type: integer
+        awb_red:
+          type: integer
+        awb_op:
+          type: boolean
+        basler_light_source_preset:
+          type: string
+          example: Daylight5000K
+        brightness:
+          type: integer
+        estimated_capture_time:
+          type: integer
+        exposure:
+          type: integer
+        focal_length:
+          type: number
+          format: float
+        focus:
+          type: integer
+          minimum: 0
+          maximum: 1600
+          example: 800
+        focus_distance:
+          type: integer
+          example: 25
+        gain:
+          type: integer
+        gamma:
+          type: integer
+        hdr_mode_enabled:
+          type: boolean
+        interval_trigger_period:
+          type: integer
+        led_gain:
+          type: integer
+          minimum: 0
+          example: 5
+        led_mode:
+          type: integer
+          minimum: 0
+          maximum: 7
+          enum: [0, 1, 2, 3, 4, 5, 6, 7]
+          example: 3
+        led_strobe_mode:
+          type: boolean
+        lens_correct:
+          type: boolean
+        photometric_enabled:
+          type: boolean
+        photometric_mode:
+          type: integer
+          minimum: 0
+          maximum: 2
+          enum: [0, 1, 2]
+        preview_image_path:
+          type: string
+          nullable: true
+        recipe_id:
+          type: integer
+        rotation_mode:
+          type: integer
+          enum: [0, 1, 2, 3]
+        smart_roi:
+          nullable: true
+        status:
+          type: string
+        trigger_debounce:
+          type: integer
+        trigger_delay:
+          type: integer

--- a/ov80i_v2026.4.0_openapi.yml
+++ b/ov80i_v2026.4.0_openapi.yml
@@ -2264,6 +2264,7 @@ components:
           type: integer
         acqMode:
           type: integer
+          enum: [1, 2, 3, 4, 5, 6]
         alignerTriggerDebounceMs:
           type: integer
         awbBlue:
@@ -2286,10 +2287,6 @@ components:
         focalLength:
           type: number
           format: float
-        focus:
-          type: integer
-        focusDistance:
-          type: integer
         gain:
           type: integer
         gamma:
@@ -2298,23 +2295,14 @@ components:
           type: boolean
         intervalTriggerPeriod:
           type: integer
-        ledGain:
-          type: integer
-        ledMode:
-          type: integer
-        ledStrobeMode:
-          type: boolean
         lensCorrect:
           type: boolean
-        photometricEnabled:
-          type: boolean
-        photometricMode:
-          type: integer
         previewImagePath:
           type: string
           nullable: true
         rotationMode:
           type: integer
+          enum: [0, 1, 2, 3]
         smartRoi:
           nullable: true
         status:
@@ -2719,6 +2707,7 @@ components:
       properties:
         acq_mode:
           type: integer
+          enum: [1, 2, 3, 4, 5, 6]
         aligner_trigger_debounce_ms:
           type: integer
         awb_blue:
@@ -2741,10 +2730,6 @@ components:
         focal_length:
           type: number
           format: float
-        focus:
-          type: integer
-        focus_distance:
-          type: integer
         gain:
           type: integer
         gamma:
@@ -2753,18 +2738,8 @@ components:
           type: boolean
         interval_trigger_period:
           type: integer
-        led_gain:
-          type: integer
-        led_mode:
-          type: integer
-        led_strobe_mode:
-          type: boolean
         lens_correct:
           type: boolean
-        photometric_enabled:
-          type: boolean
-        photometric_mode:
-          type: integer
         preview_image_path:
           type: string
           nullable: true
@@ -2772,6 +2747,7 @@ components:
           type: integer
         rotation_mode:
           type: integer
+          enum: [0, 1, 2, 3]
         smart_roi:
           nullable: true
         status:


### PR DESCRIPTION
## Summary
- **OV20i**: added missing `PATCH /edge/recipe/{id}/imaging-settings` endpoint and full `ImagingSettings` schema — the OV20i has a motorized focus lens (range 0–1600) and directional LED ring array (8 modes) but these were entirely absent from the spec
- **OV80i**: removed `focus`, `focusDistance`, `ledGain`, `ledMode`, `ledStrobeMode`, `photometricEnabled`, `photometricMode` — the OV80i does not support motorized focus or LED ring array hardware
- Enums and value ranges are derived from source code; no invented descriptions

## Test plan
- [x] Verify OV20i spec renders correctly in Swagger/Redoc
- [ ] Confirm `PATCH /edge/recipe/{id}/imaging-settings` works on an OV20i with `focus`, `led_mode`, `led_gain` fields
- [x] Confirm OV80i spec no longer documents unsupported fields